### PR TITLE
[for informative purposes only] compiled cuda train-gpt.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ python examples/data/shakespeare.py
 
 And finally, let's train a GPT:
 ```bash
-python examples/train-GPT.py
+python examples/train-gpt.py
 ```
 
 This runs on CPU and should get train loss: 1.65 and test loss: 1.80 after 2000 iterations.

--- a/examples/train-gpt.py
+++ b/examples/train-gpt.py
@@ -12,6 +12,15 @@ d_query = 32
 d_value = 32
 num_blocks = 4
 
+# Llama-7b-like values, excluding the vocabulary size.
+vocab_size = 256
+context = 1024
+num_heads = 32
+d_embed = 4096
+d_query = 128
+d_value = 128
+num_blocks = 4
+
 GPU_16BIT_FLOPS = {
     "h100-sxm": 1.979e15 / 2,
     "h100-pcie": 1.513e15 / 2,
@@ -59,10 +68,10 @@ class SpeedLogger:
 
 init_lr = 0.5
 wd = 0.01
-batch_size = 12
+batch_size = 2 # 12
 steps = 2001
 eval_steps = 100
-log_interval = 200
+log_interval = 10 # 200
 
 # let's start by defining our GPT architecture
 # (we could instead just import GPT from modula.compound)


### PR DESCRIPTION
this fork implements a small number of changes to benchmark the [MFU](https://github.com/stas00/ml-engineering/tree/eb81cd46a3b508d7ef6bd3f528134f9b7721918b/training/performance#mfu-vs-hfu) and token throughput of a reasonably large GPT (7b-like dims but only 4 layers and 256 vocab) on a single GPU.

On a 3090 (`-pl 350`), I obtain these results:
```bash
$ CUDA_VISIBLE_DEVICES=1 python examples/train-gpt.py --cuda
step: 100        train loss: 2.58        test loss: 2.59         tokens/gpu/sec: 10889.37        MFU: 74.21%
```
This is surprisingly decent, though fairly low compared to what a standard compiled implementation would achieve (~95%) on the same hardware.

A similar gap is observable on H100 (26.85% vs ~55%).

---

This PR is not (currently) meant to be merged, and is merely [here to provide useful information](https://x.com/jxbz/status/1794382842480541976). The code is currently hardcoded to use 3090's FLOPs -- though it isn't hard to auto-detect this, I didn't want to bloat the code diff for readability reasons.