### PR TITLE
Enhance GPT example user experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,165 @@
+# Custom
+examples/data/shakespeare/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,28 @@ The trained weights will be saved to `examples/data/shakespeare/weights.pt`. You
 python examples/gpt.py inference "ROMEO:"
 ```
 
+You could also generate your own dataset and train your own GPT! See `examples/data/shakespeare.py` and change the
+source text files, then train your new model:
+
+```bash
+python examples/gpt.py train \
+  --train=mydataset/train.bin \
+  --validation=mydataset/val.bin \
+  --weights=mydataset/weights.pt
+```
+
+Now you can run inference with our fresh weights:
+
+```bash
+python examples/gpt.py inference \
+  --weights=mydataset/weights.pt \
+  "JULIET:"
+```
+
+> Note: you may need to change the `chars` in `examples/gpt.py` to match the chars of your dataset.
+> If you want a more generic approach, consider using something like:
+> `chars = list(string.ascii_letters + string.digits + string.punctuation + string.whitespace)`
+
 
 ## Project roadmap
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@ python examples/data/shakespeare.py
 
 And finally, let's train a GPT:
 ```bash
-python examples/train-gpt.py
+python examples/gpt.py train
 ```
 
-This runs on CPU and should get train loss: 1.65 and test loss: 1.80 after 2000 iterations.
+This runs on CPU and should get train loss: 1.65 and test loss: 1.80 after 2000 iterations (took a few minutes).
+
+The trained weights will be saved to `examples/data/shakespeare/weights.pt`. You can now run inference:
+```bash
+python examples/gpt.py inference "ROMEO:"
+```
+
 
 ## Project roadmap
 
@@ -86,7 +92,7 @@ for step in range(steps:=20):
         mlp.normalize(grad := weights.grad())     # normalize the gradient in the modular norm
         weights -= 0.1 * grad
         weights.zero_grad()
-    
+
         mlp.regularize(weights, strength = 0.01)  # regularize the weight vector
 
     print(step, loss.item())

--- a/examples/gpt.py
+++ b/examples/gpt.py
@@ -1,3 +1,5 @@
+import time
+
 import torch
 import numpy as np
 
@@ -114,6 +116,7 @@ if __name__ == "__main__":
 
     # train the model
 
+    start = time.time()
     for step in range(steps):
 
         if step % log_interval == 0:
@@ -160,6 +163,8 @@ if __name__ == "__main__":
             weights.zero_grad()
 
         if step % log_interval == 0:
-            print(    "step:", step,
-                    "\t train loss:", "%.2f" % train_loss.item(), 
-                    "\t test loss:",  "%.2f" % test_loss.item()   )
+            print(     "step:", step,
+                    "\t train loss:", "%.2f" % train_loss.item(),
+                    "\t test loss:",  "%.2f" % test_loss.item()   ,
+                   f"\t took: {time.time() - start:.2f}s")
+            start = time.time()

--- a/examples/gpt.py
+++ b/examples/gpt.py
@@ -205,20 +205,25 @@ def inference(weights, input_text, chars_to_generate):
 
 if __name__ == "__main__":
     import argparse
+    from pathlib import Path
 
-    default_weights_filename = "examples/data/shakespeare/weights.pt"
+
+    data_path = Path(__file__).parent / "data" / "shakespeare"
+    default_weights_filename = data_path / "weights.pt"
+    default_train_filename = data_path / "train.bin"
+    default_validation_filename = data_path / "val.bin"
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="mode")
 
     parser_train = subparsers.add_parser("train")
-    parser_train.add_argument("--weights", "-w", default=default_weights_filename, help="Weights filename to save")
-    parser_train.add_argument("--train", "-t", default="examples/data/shakespeare/train.bin", help="Train dataset filename")
-    parser_train.add_argument("--validation", "-v", default="examples/data/shakespeare/val.bin", help="Validation dataset filename")
+    parser_train.add_argument("--weights", "-w", type=Path, default=default_weights_filename, help="Weights filename to save")
+    parser_train.add_argument("--train", "-t", type=Path, default=default_train_filename, help="Train dataset filename")
+    parser_train.add_argument("--validation", "-v", type=Path, default=default_validation_filename, help="Validation dataset filename")
 
     parser_inference = subparsers.add_parser("inference")
-    parser_inference.add_argument("--weights", "-w", default=default_weights_filename, help="Weights filename to load")
-    parser_inference.add_argument("--chars", "-c", default=1024, help="Number of chars to generate")
-    parser_inference.add_argument("input", help="Text to be feed into the model")
+    parser_inference.add_argument("--weights", "-w", type=Path, default=default_weights_filename, help="Weights filename to load")
+    parser_inference.add_argument("--chars", "-c", type=int, default=1024, help="Number of chars to generate")
+    parser_inference.add_argument("input", type=str, help="Text to be feed into the model")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Hi!

I was trying out Modula and, with this PR, I’ve implemented a more straightforward way to work with the GPT example. The changes include adding inference code, a command line interface, and support for using different datasets.

There’s still a fair amount of repetitive code and assumptions connecting `examples/data/shakespeare.py` and `examples/gpt.py`. If you’re open to it, I’d be glad to implement a `prepare-data` sub-command in the CLI. This would make it much easier to prepare and train on alternative datasets, which I think could be highly useful when exploring different possibilities with the tool.

Note: the [original PR](https://github.com/jxbz/modula/pull/5) was made to the old repository.