### PR TITLE
Fix type error in TupleModule (allows residual connections)

### DIFF
--- a/modula/abstract.py
+++ b/modula/abstract.py
@@ -144,14 +144,14 @@ class TupleModule(Module):
         w = []
         for m in self.children:
             key, subkey = jax.random.split(key)
-            w.append(m.initialize(subkey))
+            w += m.initialize(subkey)
         return w
 
     def project(self, w):
         projected_w = []
         for m in self.children:
             projected_w_m = m.project(w[:m.atoms])
-            projected_w.append(projected_w_m)
+            projected_w += projected_w_m
             w = w[m.atoms:]
         return projected_w
 


### PR DESCRIPTION
Changed .append to list concatenation for weights in TupleModule. The issue stems from initialize() and project() returning lists, which are appended as [[Array], [Array], ...] where Array is the underlying weight data. Children of TupleModule throw type errors reading these lists-of-lists. This commit changes TupleModule to match the implementation elsewhere, as in CompositeModule, where the weights from submodules in initialize() and project() are list concatenated. This change results in the correct type [Array, Array, ...]. Since TupleModule supports residual connections, this commit also makes residual connections possible again.